### PR TITLE
Added damping to the robot fingers to limit their movement speed

### DIFF
--- a/robots/hand.xacro
+++ b/robots/hand.xacro
@@ -67,6 +67,7 @@
       <origin xyz="0 0 0.0584" rpy="0 0 0"/>
       <axis xyz="0 1 0"/>
       <limit effort="20" lower="0.0" upper="0.04" velocity="0.2"/>
+      <dynamics damping="500.0" friction="0.0"/>
     </joint>
     <joint name="${ns}_finger_joint2" type="prismatic">
       <parent link="${ns}_hand"/>
@@ -74,6 +75,7 @@
       <origin xyz="0 0 0.0584" rpy="0 0 0"/>
       <axis xyz="0 -1 0"/>
       <limit effort="20" lower="0.0" upper="0.04" velocity="0.2"/>
+      <dynamics damping="500.0" friction="0.0"/>
       <mimic joint="${ns}_finger_joint1" />
     </joint>
   </xacro:macro>


### PR DESCRIPTION
To test this and see the difference, install panda_simulator and panda_robot (this repo, franka_panda_description, will automatically be installed as well).

Start the simulator
`roslaunch panda_gazebo panda_world.launch start_moveit:=false`

Start moveit
`roslaunch panda_sim_moveit sim_move_group.launch `

Start ipython and run the following commands interactively:
```
import rospy
from panda_robot import PandaArm

rospy.init_node('manual_control')
arm = PandaArm()
arm.untuck()

gripper = arm.get_gripper()
gripper.grasp(0.08,1)
gripper.grasp(0.,1)
```
Before the change, the gripper opened almost instantly. After the change, it takes about 1 second to open or close the gripper.